### PR TITLE
Blocks Support

### DIFF
--- a/quick-weblog.php
+++ b/quick-weblog.php
@@ -156,7 +156,13 @@ function quick_weblog_submit_form() {
   $block_name = 'core/paragraph';
   $innerHTML  = 'Sample paragraph text.';
 
-  $converted_block = new WP_Block_Parser_Block( $block_name, array(), array(), $innerHTML, array( $innerHTML ) );
+  $converted_block = new WP_Block_Parser_Block(
+    $block_name, // Name of block @example "core/paragraph"
+    array(), // Optional set of attributes from block comment delimiters @example array( 'columns' => 3 )
+    array(), // List of inner blocks (of this same class)
+    $innerHTML, // Resultant HTML from inside block comment delimiters after removing inner blocks
+    array( $innerHTML ) // List of string fragments and null markers where inner blocks were found
+  );
   // WP_CLI::log( print_r( $converted_block, true ) );
 
   $serialized_block = serialize_block( (array) $converted_block );

--- a/quick-weblog.php
+++ b/quick-weblog.php
@@ -148,6 +148,29 @@ function quick_weblog_submit_form() {
     'tags_input' => $tags,
     'post_status' => 'publish'
   );
+
+  /*
+  * Create a block programmatically and serialize it.
+  * https://developer.wordpress.org/reference/functions/serialize_block/
+  */
+  $block_name = 'core/paragraph';
+  $innerHTML  = 'Sample paragraph text.';
+
+  $converted_block = new WP_Block_Parser_Block( $block_name, array(), array(), $innerHTML, array( $innerHTML ) );
+  // WP_CLI::log( print_r( $converted_block, true ) );
+
+  $serialized_block = serialize_block( (array) $converted_block );
+  // WP_CLI::log( $serialized_block );
+
+  // Create a new post
+  $post_data = array(
+    'post_title' => $title,
+    'post_content' => $serialized_block,
+    'post_category' => array( $category ),
+    'tags_input' => $tags,
+    'post_status' => 'publish'
+  );
+
   $post_id = wp_insert_post( $post_data );
 
   // Redirect to the new post

--- a/quick-weblog.php
+++ b/quick-weblog.php
@@ -148,29 +148,6 @@ function quick_weblog_submit_form() {
     'tags_input' => $tags,
     'post_status' => 'publish'
   );
-
-  /*
-  * Create a block programmatically and serialize it.
-  * https://developer.wordpress.org/reference/functions/serialize_block/
-  */
-  $block_name = 'core/paragraph';
-  $innerHTML  = 'Sample paragraph text.';
-
-  $converted_block = new WP_Block_Parser_Block( $block_name, array(), array(), $innerHTML, array( $innerHTML ) );
-  // WP_CLI::log( print_r( $converted_block, true ) );
-
-  $serialized_block = serialize_block( (array) $converted_block );
-  // WP_CLI::log( $serialized_block );
-
-  // Create a new post
-  $post_data = array(
-    'post_title' => $title,
-    'post_content' => $serialized_block,
-    'post_category' => array( $category ),
-    'tags_input' => $tags,
-    'post_status' => 'publish'
-  );
-
   $post_id = wp_insert_post( $post_data );
 
   // Redirect to the new post

--- a/quick-weblog.php
+++ b/quick-weblog.php
@@ -132,18 +132,25 @@ function quick_weblog_submit_form() {
   $category = intval( $_POST['category'] );
   $tags = sanitize_text_field( $_POST['tags'] );
 
+  // Create block content
+  $image_block = '<!-- wp:image {"url":"' . esc_attr($image_url) . '","alt":"' . esc_attr($image_description) . '"} -->' .
+      '<figure class="wp-block-image">' .
+          '<img src="' . esc_url($image_url) . '" alt="' . esc_attr($image_description) . '">' .
+          '<figcaption>' . esc_html($image_description) . '</figcaption>' .
+      '</figure><!-- /wp:image -->';
+
+  $quote_block = '<!-- wp:quote {"citation":"' . esc_attr($url) . '"} -->' .
+      '<blockquote class="wp-block-quote">' .
+          '<p>' . esc_html($quote) . '</p>' .
+          '<cite><a href="' . esc_url($url) . '" target="_blank" rel="noreferrer noopener">' . esc_html($url) . '</a></cite>' .
+      '</blockquote><!-- /wp:quote -->';
+
+  $block_content = $image_block . $quote_block;
+
   // Create a new post
   $post_data = array(
     'post_title' => $title,
-    'post_content' => sprintf( '
-      <blockquote class="wp-block-quote">
-        <figure class="wp-block-image">
-          <img decoding="async" src="%s" alt>
-          <figcaption class="wp-element-caption">%s</figcaption>
-        </figure><p>%s</p>
-        <cite><a href="%s" target="_blank" rel="noreferrer noopener">%s</a></cite>
-      </blockquote>'
-      , $image_url, $image_description, $quote, $url, $url ),
+    'post_content' => $block_content,
     'post_category' => array( $category ),
     'tags_input' => $tags,
     'post_status' => 'publish'

--- a/quick-weblog.php
+++ b/quick-weblog.php
@@ -156,13 +156,7 @@ function quick_weblog_submit_form() {
   $block_name = 'core/paragraph';
   $innerHTML  = 'Sample paragraph text.';
 
-  $converted_block = new WP_Block_Parser_Block(
-    $block_name, // Name of block @example "core/paragraph"
-    array(), // Optional set of attributes from block comment delimiters @example array( 'columns' => 3 )
-    array(), // List of inner blocks (of this same class)
-    $innerHTML, // Resultant HTML from inside block comment delimiters after removing inner blocks
-    array( $innerHTML ) // List of string fragments and null markers where inner blocks were found
-  );
+  $converted_block = new WP_Block_Parser_Block( $block_name, array(), array(), $innerHTML, array( $innerHTML ) );
   // WP_CLI::log( print_r( $converted_block, true ) );
 
   $serialized_block = serialize_block( (array) $converted_block );


### PR DESCRIPTION
Update post creation so that when opened in the editor, block format is retained. Previously, if you opened a post from this plugin in the WP editor, it would be listed as Classic HTML.